### PR TITLE
clean up entry page

### DIFF
--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,38 +1,33 @@
 import React from 'react'
-import Link from 'next/link'
 import App from '@/lib/ui/App'
 import Background from '@/pistols/components/Background'
 import Logo from '@/pistols/components/Logo'
-import { usePlayerId } from '@/lib/dojo/hooks/usePlayerId'
+import { Button } from 'semantic-ui-react'
 
 export default function IndexPage() {
-  const { playerId } = usePlayerId()
   return (
     <App>
       <Background className='BackgroundSplash'>
         <div className='AlignCenter'>
-
-          <Link href='https://pistols.underware.gg/gate'>
-            <Logo />
-          </Link>
-
+          <Logo />
           <div className='Spacer20' />
-
-          <Link href='https://pistols.underware.gg/gate'>
-            <h1 className='TitleCase'>Pistols at 10 Blocks</h1>
-          </Link>
-
+          <h1 className='TitleCase'>Pistols at 10 Blocks</h1>
           <hr />
-
           <h5>
             an [<a href='https://x.com/LootUnderworld'>Underworld</a>] game
           </h5>
           <h5>
             <span>by</span> [<a href='https://underware.gg'>Underware</a>]
           </h5>
-
+          <div className='Spacer20' />
+          <Button
+            as='a'
+            href='./gate'
+            target='_blank'
+          >
+            Enter Tavern
+          </Button>
           <div style={{ height: '5vh' }}>&nbsp;</div>
-
         </div>
       </Background>
     </App>


### PR DESCRIPTION
# What was changed?

- Added an enter tavern button (link)
- removed the link around the logo and the h1 tag.
- removed the unused code for getting the player id from dojo in the title screen.
- fixed a bug where locally the link was directing to the prod version.

<img width="767" alt="Screenshot 2024-07-29 at 11 43 24 AM" src="https://github.com/user-attachments/assets/e6a5fb51-a75a-4c7e-ba58-c8e8d4a0f0c4">
